### PR TITLE
Added support for different TS compile destination 

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,27 +1,29 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as host from 'host';
 
-function isFileEmit(fileName, outputFileName)  {
-    return (outputFileName.replace(/\.js$/, '.ts') === fileName) ||
-           (outputFileName.replace(/\.js$/, '.tsx') === fileName);
+function isFileEmit(fileName, outputFileName, sourceFileName) {
+    return sourceFileName === fileName
+        && outputFileName.substr(-3) === '.js';
 }
 
-function isSourceMapEmit(fileName, outputFileName)  {
-    return (outputFileName.replace(/\.js\.map$/, '.ts') === fileName) ||
-           (outputFileName.replace(/\.js\.map$/, '.tsx') === fileName);
+function isSourceMapEmit(fileName, outputFileName, sourceFileName) {
+    return sourceFileName === fileName
+        && outputFileName.substr(-7) === '.js.map';
 }
 
-export function findResultFor(output: ts.EmitOutput, fileName: string) {
+export function findResultFor(output:host.IEmitOutput, fileName:string) {
     let text;
     let sourceMap;
     fileName = path.normalize(fileName);
     for (let i = 0; i < output.outputFiles.length; i++) {
         let o = output.outputFiles[i];
         let outputFileName = path.normalize(o.name);
-        if (isFileEmit(fileName, outputFileName)) {
+        let sourceFileName = path.normalize(o.sourceName);
+        if (isFileEmit(fileName, outputFileName, sourceFileName)) {
             text = o.text;
         }
-        if (isSourceMapEmit(fileName, outputFileName)) {
+        if (isSourceMapEmit(fileName, outputFileName, sourceFileName)) {
             sourceMap = o.text;
         }
     }

--- a/src/host.ts
+++ b/src/host.ts
@@ -40,6 +40,14 @@ export interface ICompilerOptions extends ts.CompilerOptions {
     forkChecker?: boolean;
 }
 
+export interface IOutputFile extends ts.OutputFile {
+    sourceName: string
+}
+
+export interface IEmitOutput extends ts.EmitOutput {
+    outputFiles: IOutputFile[]
+}
+
 export class Host implements ts.LanguageServiceHost {
 
     state: State;
@@ -150,23 +158,25 @@ export class State {
         this.program = this.services.getProgram();
     }
 
-    emit(fileName: string): ts.EmitOutput {
+    emit(fileName: string): IEmitOutput {
 
         if (!this.program) {
             this.program = this.services.getProgram();
         }
 
-        let outputFiles: ts.OutputFile[] = [];
+        let outputFiles: IOutputFile[] = [];
+
+        let normalizedFileName = this.normalizePath(fileName);
 
         function writeFile(fileName: string, data: string, writeByteOrderMark: boolean) {
             outputFiles.push({
+                sourceName: normalizedFileName,
                 name: fileName,
                 writeByteOrderMark: writeByteOrderMark,
                 text: data
             });
         }
 
-        let normalizedFileName = this.normalizePath(fileName);
         let source = this.program.getSourceFile(normalizedFileName);
         if (!source) {
             this.updateProgram();


### PR DESCRIPTION
if outDir option in tsconfig.json is set, input and output files have different paths and loader produces error 'no output found' since it can not match produced files with source files. 

This PR fixes that. 