### PR TITLE
Fixes issues under windows with typescript 1.6, and moduleResolution flags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,14 @@ function ensureInstance(webpack: IWebPack, options: ICompilerOptions, instanceNa
             tsConfigFiles = configFile.config.files || tsConfigFiles;
         }
     }
+    if (typeof options.moduleResolution === "string") {
+       var moduleTypes = {
+           "node": tsImpl.ModuleResolutionKind.NodeJs,
+           "classic": tsImpl.ModuleResolutionKind.Classic
+       };
+        options.moduleResolution = moduleTypes[options.moduleResolution];
+
+    }
 
     if (typeof options.emitRequireType === 'undefined') {
         options.emitRequireType = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,7 @@ function ensureInstance(webpack: IWebPack, options: ICompilerOptions, instanceNa
 
             if (forkChecker) {
                 let payload = {
-                    files: state.files,
+                    files: state.allFiles(),
                     resolutionCache: state.host.moduleResolutionHost.resolutionCache
                 };
 
@@ -363,7 +363,7 @@ function ensureInstance(webpack: IWebPack, options: ICompilerOptions, instanceNa
             }
 
             let phantomImports = [];
-            Object.keys(state.files).forEach((fileName) => {
+            state.allFileNames().forEach((fileName) => {
                 if (!instance.compiledFiles[fileName]) {
                     phantomImports.push(fileName)
                 }


### PR DESCRIPTION
There were a couple of problems here, fixed over two commits. Firstly, if a moduleResolution option was given in the tsconfig.json file, awesome-typescript would fail to compile any files. This was a problem if you needed "classic" resolution.

The other problem occurred with relative paths. Under windows, some paths weren't being normalized by awesome-typescript-loader, resulting in `C:\site\file.ts` instead of `C:/site/file.ts`. When compared, these were found to be not equal. This was fixed by normalizing all paths before they were saved in the State class.