### PR TITLE
Fixed live reloading in windows, fixes #72

### DIFF
--- a/src/host.ts
+++ b/src/host.ts
@@ -353,8 +353,8 @@ export class State {
         return this.updateFile(fileName, text, checked);
     }
 
-    normalizePath(path: string): string {
-        return (<any>this.ts).normalizePath(path)
+    normalizePath(filePath: string): string {
+        return path.normalize(filePath);
     }
 }
 


### PR DESCRIPTION
This fixes the hot reloading for typescript. The problem occurred because webpack expected windows path with backslashes, but the typescript normalizePath function used forward slashes.

I've tested this with both building and using the webpack-dev-server for both html/css/ts files and they all work correctly.

Fixes #72 

