### PR TITLE
Emit declaration files into the correct location based on WebPack's context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,10 +121,17 @@ async function compiler(webpack: IWebPack, text: string): Promise<void> {
                     }
 
                     if (result.declaration) {
-                        webpack.emitFile(
-                            path.relative(process.cwd(), result.declaration.sourceName),
-                            result.declaration.text
+                        const dtsPath: string = loaderUtils.interpolateName(
+                            {
+                                resourcePath: result.declaration.sourceName,
+                                options: webpack.options
+                            },
+                            '[path][name].[ext]',
+                            {
+                                context: webpack.options.context
+                            }
                         );
+                        webpack.emitFile(dtsPath, result.declaration.text);
                     }
 
                     resultText = result.text;

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -60,6 +60,7 @@ export interface IWebPack {
     clearDependencies: () => void;
     emitFile: (fileName: string, text: string) => void;
     options: {
+        context: string;
         atl?: {
             plugins: LoaderPluginDef[]
         }

--- a/src/test/declaration.ts
+++ b/src/test/declaration.ts
@@ -26,4 +26,30 @@ describe('main test', function() {
         // elided import
         expect(assets).to.include('src/test/fixtures/declaration/iface.d.ts');
     });
+
+    it('should emit declaration files in context', async function() {
+        this.timeout(10000);
+
+        let config = {
+            context: fixturePath(['declaration']),
+            entry: {
+                'basic': fixturePath(['declaration', 'basic.ts'])
+            }
+        };
+
+        let loaderQuery = {
+            declaration: true
+        };
+
+        let stats = await cleanAndCompile(createConfig(config, { loaderQuery }));
+        expect(stats.compilation.errors.length).eq(0);
+
+        let assets = Object.keys(stats.compilation.assets);
+
+        expect(assets).to.include('basic.d.ts');
+        expect(assets).to.include('basic.js');
+
+        // TODO: Code should be changed to output elided import into the correct location
+        expect(assets).to.include('src/test/fixtures/declaration/iface.d.ts');
+    });
 });


### PR DESCRIPTION
Given the following project structure:

```
project/
    src/
        thing1.ts
        thing2.ts
```

and the following WebPack configuration:

```js
module.exports = {
    context: 'src',
    entry: {
        thing1: 'thing1.ts',
        thing2: 'thing2.ts'
    },
    output: {
        path: path.join(__dirname, 'dist'),
        filename: '[name].js',
        libraryTarget: 'umd'
    },
    resolve: {
        extensions: [ '', '.ts', '.js' ],
        root: 'src'
    },
    module: {
        loaders: [
            {
                test: /\.ts$/,
                loader: 'awesome-typescript-loader',
                query: {
                    declaration: true
                }
            }
        ]
    }
};
```

The following directory structure is created:

```
project/
    dist/
        src/
            thing1.d.ts
            thing2.d.ts
        thing1.js
        thing2.js
```

This pull request updates the declaration file destination calculation to use WebPack's `loaderUtils` to determine where to emit the declaration file. This pull request does not cover "elided" declaration files which will still output with the incorrect path.