### PR TITLE
fix: ReferenceError: ts is not defined

### DIFF
--- a/src/host.ts
+++ b/src/host.ts
@@ -144,7 +144,7 @@ export class State {
                     type,
                     this.configFilePath,
                     options,
-                    ts.sys
+                    this.ts.sys
                 );
 
                 if (resolvedTypeReferenceDirective) {


### PR DESCRIPTION
Awesome-typescript-loader throws the following error when types are used in tsconfig.json
```
ERROR in ./src/main/frontend/main.ts
Module build failed: ReferenceError: ts is not defined
    at C:\dev\projects\spring-angular2-starter\shardis-ui\node_modules\awesome-typescript-loader\src\host.ts:143:23
    at Array.forEach (native)
    at State.loadTypesFromConfig (C:\dev\projects\spring-angular2-starter\shardis-ui\node_modules\awesome-typescript-loader\src\host.ts:142:27)
    at new State (C:\dev\projects\spring-angular2-starter\shardis-ui\node_modules\awesome-typescript-loader\src\host.ts:136:14)
    at Object.ensureInstance (C:\dev\projects\spring-angular2-starter\shardis-ui\node_modules\awesome-typescript-loader\src\instance.ts:151:19)
    at compiler (C:\dev\projects\spring-angular2-starter\shardis-ui\node_modules\awesome-typescript-loader\src\index.ts:39:20)
    at Object.loader (C:\dev\projects\spring-angular2-starter\shardis-ui\node_modules\awesome-typescript-loader\src\index.ts:20:18)
```

This fix should resolve the issue