### PR TITLE
Apply https://github.com/TypeStrong/ts-loader/pull/167 

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -347,7 +347,7 @@ function setupWatchRun(compiler, instanceName: string) {
     compiler.plugin('watch-run', function (watching, callback) {
         let instance = resolveInstance(watching.compiler, instanceName);
         let state = instance.tsState;
-        let mtimes = watching.compiler.watchFileSystem.watcher.mtimes;
+        let mtimes = watching.compiler.fileTimestamps || watching.compiler.watchFileSystem.watcher.mtimes;
         let changedFiles = Object.keys(mtimes).map(toUnix);
 
         changedFiles.forEach((changedFile) => {


### PR DESCRIPTION
to improve watch stability when using OldWatchPlugin or WatchIgnorePlugin.

See https://github.com/TypeStrong/ts-loader/issues/155