### PR TITLE
Remove file extensions while resolving dependencies.

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,5 @@
 import { State } from './host';
+import { withoutTypeScriptExtension } from './helpers';
 import * as path from 'path';
 type FileSet = {[fileName: string]: boolean};
 
@@ -74,7 +75,8 @@ export class FileAnalyzer {
         imports.push.apply(imports, info.importedFiles
             .map(file => file.fileName)
             .map(depName => {
-                let { resolvedModule } = ts.resolveModuleName(depName, fileName, options, ts.sys);
+                let moduleName = withoutTypeScriptExtension(depName);
+                let { resolvedModule } = ts.resolveModuleName(moduleName, fileName, options, ts.sys);
                 if (resolvedModule) {
                     deps.addModuleResolution(fileName, depName, resolvedModule);
                     return resolvedModule.resolvedFileName;
@@ -91,7 +93,8 @@ export class FileAnalyzer {
                 return path.resolve(path.dirname(fileName), relative);
             })
             .map(depName => {
-                let { resolvedModule } = ts.resolveModuleName(depName, fileName, options, ts.sys);
+                let moduleName = withoutTypeScriptExtension(depName);
+                let { resolvedModule } = ts.resolveModuleName(moduleName, fileName, options, ts.sys);
                 if (resolvedModule) {
                     deps.addModuleResolution(fileName, depName, resolvedModule);
                     // return non-realpath name (symlinks not resolved)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -113,3 +113,9 @@ export function loadLib(moduleId) {
         text: text
     };
 }
+
+const TYPESCRIPT_EXTENSION = /\.(d\.)?(t|j)s$/;
+
+export function withoutTypeScriptExtension(fileName: string): string {
+    return fileName.replace(TYPESCRIPT_EXTENSION, '');
+}

--- a/src/host.ts
+++ b/src/host.ts
@@ -145,7 +145,7 @@ export class State {
     loadTypesFromConfig() {
         let { options } = this.compilerConfig;
 
-        const directives = this.ts.getAutomaticTypeDirectiveNames(options, [], this.compilerHost);
+        const directives = this.ts.getAutomaticTypeDirectiveNames(options, this.compilerHost);
 
         if (directives) {
             directives.forEach(type => {


### PR DESCRIPTION
As of https://github.com/Microsoft/TypeScript/pull/9646, TypeScript no longer expects extensions
in dependency resolution functions.

This should fix https://github.com/s-panferov/awesome-typescript-loader/issues/221.