### PR TITLE
add `typescript` as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "tslint": "^3.14.0",
     "typescript": "^2.0.2",
     "webpack": "2.1.0-beta.4"
+  },
+  "peerDependencies": {
+    "typescript": ">= 2.0.2"
   }
 }


### PR DESCRIPTION
This will prevent issues like #226 and #229 from being raised again
(hopefully).

`awesome-typescript-loader` 2.2.3 onwards broke
compatibility with TypeScript 2.0 and some people (including myself)
depended on it. Unfortunately, it failed silently, leaving a rather
cryptic error. TypeScript's dependency was updated as a devDependency on
this package to 2.0.2, however TypeScript itself has never been
installed as a peerDependency.

Adding TypeScript as a peerDependency will alert consumers of this
package when they install a version of TypeScript that is not supported
by this plugin.

Of course, perhaps `>= 2.0.2` is too weak a constraint, but it's better
than none.

Here's what will be displayed if you install a version below the required version (in this example I installed TypeScript 2.0.0)

![example console output](https://i.imgur.com/lfffGKC.png)
