### PR TITLE
chore(ver): loader-utils 0.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "enhanced-resolve": "^2.2.2",
-    "loader-utils": "^0.2.6",
+    "loader-utils": "^0.2.16",
     "lodash": "^4.13.1",
     "object-assign": "^4.1.0",
     "source-map-support": "^0.4.0"


### PR DESCRIPTION
Because of there is some important [changes](https://github.com/webpack/loader-utils/blob/master/index.js#L67) in loader-utils