### PR TITLE
Fix `TypeError: Cannot set property 'exclude' of undefined`

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -196,6 +196,7 @@ function setupBabel(loaderConfig: LoaderConfig): any {
 }
 
 function applyDefaults(configFilePath: string, compilerConfig: TsConfig, loaderConfig: LoaderConfig) {
+    compilerConfig.typingOptions = compilerConfig.typingOptions || {};
     compilerConfig.typingOptions.exclude = compilerConfig.typingOptions.exclude || [];
 
     _.defaults(compilerConfig.options, {


### PR DESCRIPTION
TypeScript 2.2's compilerConfig does not seem to include a typingOptions key.

I'm not sure if this can typecheck, but it does fix a runtime crash.