### PR TITLE
[WIP] fix for concurrent webpack config "channel closed" error

### DIFF
--- a/src/checker/checker.ts
+++ b/src/checker/checker.ts
@@ -136,7 +136,7 @@ export class Checker {
     }
 
     kill() {
-        this.checker.kill('SIGKILL');
+        this.checker.kill('SIGTERM');
     }
 }
 

--- a/src/checker/runtime.ts
+++ b/src/checker/runtime.ts
@@ -7,6 +7,11 @@ process.on('disconnect', function() {
     process.exit();
 });
 
+// HACK keepalive for concurrent webpack config
+process.on('SIGTERM', function () {
+    // do nothing
+});
+
 import * as path from 'path';
 import * as colors from 'colors';
 import { findResultFor } from '../helpers';
@@ -230,7 +235,6 @@ function processInit({seq, payload}: Init.Request) {
             ignoreDiagnostics[diag] = true;
         });
     }
-
 
     replyOk(seq, null);
 }


### PR DESCRIPTION
I really know nothing about these different signals as I'm more of a web dev, so right now these changes are a bit of a hack - but it does prevent the "channel closed" error in #287.

I understand that leaving a forked process like this long running is a bit of a bad practice though, so I'm happy to receive any input on how to improve this :)

/cc @s-panferov does this by any chance indicate a path to a proper fix in your mind?