### PR TITLE
Support require() with non-JS files, as in webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module.exports = {
 
   // Currently we need to add '.ts' to the resolve.extensions array.
   resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.jsx']
+    extensions: ['', '.ts', '.tsx', '.js', '.jsx']
   },
 
   // Source maps support ('inline-source-map' also works)


### PR DESCRIPTION
Fixes #146

Webpack supports loading images, css, text, json, csv, html and any other file type as a module through `require()`.  The default documentation for ATL breaks this support though.