### PR TITLE
fix: Create file references for typescriptServices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/test/output
 .vagrant
 Vagrantfile
 issues
+.idea

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "watch:ts": "npm run build:ts -- --watch --diagnostics",
     "prebuild": "npm run lint",
     "compile": "tsc --pretty",
-    "build": "rm -rf dict && tsc -p prod --pretty",
+    "build": "rm -rf dist && tsc -p prod --pretty",
     "lint": "tslint src/*.ts",
     "release": "standard-version"
   },

--- a/prod/tsconfig.json
+++ b/prod/tsconfig.json
@@ -11,6 +11,9 @@
         "suppressImplicitAnyIndexErrors": true,
         "lib": [ "es6", "dom" ]
     },
+    "files": [
+        "../node_modules/typescript/lib/typescriptServices.d.ts"
+    ],
     "compileOnSave": false,
     "include": [
         "../src/**/*"

--- a/src/defines.d.ts
+++ b/src/defines.d.ts
@@ -1,1 +1,0 @@
-/// <reference types='typescript/lib/typescriptServices' />

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-/// <reference path="./defines.d.ts" />
-
 import * as _ from 'lodash';
 import * as path from 'path';
 

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,5 +1,3 @@
-/// <reference path="../defines.d.ts" />
-
 import * as path from 'path';
 import * as fs from 'fs';
 import * as _ from 'lodash';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
         "suppressImplicitAnyIndexErrors": true,
         "lib": [ "es6", "dom" ]
     },
+    "files": [
+        "node_modules/typescript/lib/typescriptServices.d.ts"
+    ],
     "compileOnSave": false,
     "include": [
         "src/**/*"


### PR DESCRIPTION
Based on my research on issue #326 It seems like we should be using file references going forward.

These commits make a few minor fixes/tweaks and switch to using file references from the tsconfig.json as this is the current preferred way to add file references to a project.

I believe this should fix most of the issues that are breaking the build. In general, we should switch back to module references I believe, but better to fix build and then make a decision about that