### PR TITLE
Fix: Add hack to stop null exception

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -211,6 +211,10 @@ function setupBabel(loaderConfig: LoaderConfig): any {
 }
 
 function applyDefaults(configFilePath: string, compilerConfig: TsConfig, loaderConfig: LoaderConfig) {
+    // HACK: adding in a blank initializer to stop loader from crashing, 
+    // see s-panferov/awesome-typescript-loader#190 for more details
+    compilerConfig.raw.compilerOptions.exclude = compilerConfig.raw.compilerOptions.exclude || [];
+    
     _.defaults(compilerConfig.options, {
         sourceMap: true,
         verbose: false,


### PR DESCRIPTION
In lieu of overall rewrites, there is a crash with a null reference error.

Adding fix suggested by @sdudziak to deal with this in the short term

A larger rewrite will be necesary to deal with Webpack 2 and typescript 2.1