### PR TITLE
fix: undefined error on result.deps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ function compiler(loader: Loader, text: string): void {
 
     transformation
         .then(({cached, result}) => {
-            if (!instance.compilerConfig.options.isolatedModules) {
+            if (!instance.compilerConfig.options.isolatedModules && result.deps) {
                 // If our modules are isolated we don't need to recompile all the deps
                 result.deps.forEach(dep => loader.addDependency(path.normalize(dep)));
             }


### PR DESCRIPTION
Had an error where result.deps was undefined. Can't honestly explain the root cause, but this addition fixes the error for me.