### PR TITLE
Fixes a case where windows + awesome-typescript-loader can still hang waiting for IPC with the checker

### DIFF
--- a/src/checker/send.ts
+++ b/src/checker/send.ts
@@ -4,8 +4,6 @@ export interface QueuedSender {
     send: (msg: any) => void;
 }
 
-const isWindows = /^win/.test(process.platform);
-
 // Wrapper around process.send() that will queue any messages if the internal node.js
 // queue is filled with messages and only continue sending messages when the internal
 // queue is free again to consume messages.
@@ -13,32 +11,34 @@ const isWindows = /^win/.test(process.platform);
 // to workaround https://github.com/nodejs/node/issues/7657 (IPC can freeze process)
 export function createQueuedSender(childProcess: ChildProcess | NodeJS.Process): QueuedSender {
     let msgQueue = [];
-    let useQueue = false;
+    let isSending = false;
+
+    const doSendLoop = function(): void {
+        const msg = msgQueue.shift();
+
+        childProcess.send(msg, error => {
+            if (error) {
+                console.error(error);
+            }
+
+            if (msgQueue.length > 0) {
+                setImmediate(doSendLoop);
+            } else {
+                isSending = false;
+            }
+        });
+    };
 
     const send = function (msg: any): void {
-        if (useQueue) {
-            msgQueue.push(msg); // add to the queue if the process cannot handle more messages
+        msgQueue.push(msg); // add to the queue if the process cannot handle more messages
+
+        if (isSending) {
             return;
         }
 
-        let result = childProcess.send(msg, error => {
-            if (error) {
-                console.error(error); // unlikely to happen, best we can do is log this error
-            }
+        isSending = true;
 
-            useQueue = false; // we are good again to send directly without queue
-
-            // now send all the messages that we have in our queue and did not send yet
-            if (msgQueue.length > 0) {
-                const msgQueueCopy = msgQueue.slice(0);
-                msgQueue = [];
-                msgQueueCopy.forEach(entry => send(entry));
-            }
-        });
-
-        if (!result || isWindows /* workaround https://github.com/nodejs/node/issues/7657 */) {
-            useQueue = true;
-        }
+        doSendLoop();
     };
 
     return { send };


### PR DESCRIPTION
fix the RPC sending to loop with a delay between each send to alleviate pressure on the RPC pipe.

The key here is to setImmediate between processing messages, note that this is a similar work-around to how vscode ts support works - only their queue is promise based, so the delay is implicit.