### PR TITLE
feat: Add muteNodeModules option

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Use pre-compiled files if any. Files must be named as `{filename}.js` and `{file
 
 Directory when cache is stored.
 
+### muteNodeModules *(boolean) (default=false)*
+
+Mute TypeScript Errors that occur in libraries in the node_modules folder.
+
 ## Compiler options
 
 You can pass compiler options inside loader query string or in tsconfig file.

--- a/src/checker/runtime.ts
+++ b/src/checker/runtime.ts
@@ -344,6 +344,7 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
 
     function processDiagnostics({seq}: Diagnostics.Request) {
         let silent = !!loaderConfig.silent;
+        const muteNodeModules = !!loaderConfig.muteNodeModules;
 
         const timeStart = +new Date();
 
@@ -369,6 +370,12 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
         }
 
         const processedDiagnostics = allDiagnostics
+            .filter(diag => {
+                if (muteNodeModules && diag.file) {
+                    return !/node_modules/.test(diag.file.fileName)
+                }
+                return true
+            })
             .filter(diag => !ignoreDiagnostics[diag.code])
             .map(diagnostic => {
                 const message = compiler.flattenDiagnosticMessageText(diagnostic.messageText, '\n');

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ export interface LoaderConfig {
     silent?: boolean;
     useCache?: boolean;
     cacheDirectory?: string;
+    muteNodeModules?: boolean;
 }
 
 export interface OutputFile {


### PR DESCRIPTION
It happened already a lot to us, that there are typescript dependencies that have errors based on name clashes or other problems.
As it is not always something you can fix immediately as an app developer, it makes sense, until the issue is resolved, to just mute the errors occurring in libraries.
That way you again have a clear webpack output and can see the relevant errors and warnings of your project.