### PR TITLE
update loader-utils to ^1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "enhanced-resolve": "^3.1.0",
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.0.2",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function compiler(loader: Loader, text: string): void {
 
     const rootCompiler = getRootCompiler(loader._compiler);
 
-    const query = <QueryOptions>loaderUtils.parseQuery(loader.query);
+    const query = <QueryOptions>loaderUtils.getOptions(loader);
     const options = (loader.options && loader.options.ts) || {};
     const instanceName = query.instance || 'at-loader';
     const instance = ensureInstance(loader, query, options, instanceName, rootCompiler);


### PR DESCRIPTION
loader-utils 0.2.17 shows a [deprecation warning](https://github.com/webpack/loader-utils/pull/57/files) for parseQuery. It shows when you pass the options as object to awesome-typescript-loader like:

```javascript
            rules: [
                {
                    test: /\.ts$/,
                    use: {
                        loader: `awesome-typescript-loader`,
                        query: {
                            configFileName: `${param.sourceRoot}/js/tsconfig.json`,
                        }
                    },
                },
``` 

you see:
![image](https://cloud.githubusercontent.com/assets/905328/23208641/11f99866-f8f6-11e6-88aa-fbe8f1f818ce.png)

This PR updates to 1.0.2 and uses the new `getOptions` method.