### PR TITLE
Fix: add check for missing "mtimes"

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -330,7 +330,7 @@ function setupWatchRun(compiler, instanceName: string) {
         const watcher = watching.compiler.watchFileSystem.watcher
             || watching.compiler.watchFileSystem.wfs.watcher;
 
-        const mtimes = watcher.mtimes;
+        const mtimes = watcher.mtimes || {};
         const changedFiles = Object.keys(mtimes).map(toUnix);
         const updates = changedFiles
             .filter(file => EXTENSIONS.test(file))


### PR DESCRIPTION
`watchpack 1.3.0` no longer returns `mtimes` and build fails
Fixes https://github.com/s-panferov/awesome-typescript-loader/issues/378