### PR TITLE
feat: Ensure errors are outputted as relative paths (i.e. begin with './')

### DIFF
--- a/src/__test__/error.ts
+++ b/src/__test__/error.ts
@@ -17,6 +17,7 @@ spec(__filename, async function() {
     let stats = await compile(webpackConfig());
 
     expectErrors(stats, 1, [
+        './src/index.ts',
         `Argument of type '"test"' is not assignable to parameter of type 'number'`
     ]);
 

--- a/src/checker/runtime.ts
+++ b/src/checker/runtime.ts
@@ -407,7 +407,8 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
             .filter(diag => !ignoreDiagnostics[diag.code])
             .map(diagnostic => {
                 const message = compiler.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-                const fileName = diagnostic.file && path.relative(context, diagnostic.file.fileName);
+                const fileName = diagnostic.file && './'+path.relative(context, diagnostic.file.fileName);
+                
                 let pretty = '';
                 let line = 0;
                 let character = 0;


### PR DESCRIPTION
When outputting the diagnostics from a compiled file, the filename would be outputted relative to the context the loader was run, but without a leading './'. This PR adds this leading './'
