### PR TITLE
bug: hasOwnProperty type guard object patch emits errors on recompile

### DIFF
--- a/src/__test__/watch-object-patch.ts
+++ b/src/__test__/watch-object-patch.ts
@@ -1,0 +1,94 @@
+import {
+    src, webpackConfig, tsconfig,
+    watch, expectErrors, spec
+} from './utils';
+
+spec('just patch Object interface', async function() {
+    src('index.ts', `
+        interface Object {
+            hasOwnProperty<K extends PropertyKey>(k: K): this is {[_ in K]: any }
+        }
+
+        interface TypeA {}
+        interface TypeB {
+            bar: boolean;
+        }
+
+        type UnionType = TypeA | TypeB;
+
+        const foo: UnionType = {
+            bar: true
+        }
+
+        if (!foo.hasOwnProperty('bar')) {
+            throw new Error();
+        }
+
+        foo.bar
+    `);
+
+    tsconfig();
+
+    const watcher = watch(webpackConfig());
+
+    let stats = await watcher.wait();
+    expectErrors(stats, 0);
+});
+
+spec('patch Object interface and recompile (remove empty line)', async function() {
+    const index = src('index.ts', `
+        interface Object {
+            hasOwnProperty<K extends PropertyKey>(k: K): this is {[_ in K]: any }
+        }
+
+        interface TypeA {}
+        interface TypeB {
+            bar: boolean;
+        }
+
+        type UnionType = TypeA | TypeB;
+
+        const foo: UnionType = {
+            bar: true
+        }
+
+        if (!foo.hasOwnProperty('bar')) {
+            throw new Error();
+        }
+
+        foo.bar
+    `);
+
+    tsconfig();
+
+    const watcher = watch(webpackConfig());
+
+    let stats = await watcher.wait();
+    expectErrors(stats, 0);
+
+    index.update(() => `
+        interface Object {
+            hasOwnProperty<K extends PropertyKey>(k: K): this is {[_ in K]: any }
+        }
+
+        interface TypeA {}
+        interface TypeB {
+            bar: boolean;
+        }
+
+        type UnionType = TypeA | TypeB;
+
+        const foo: UnionType = {
+            bar: true
+        }
+
+        if (!foo.hasOwnProperty('bar')) {
+            throw new Error();
+        }
+        foo.bar
+    `);
+
+    stats = await watcher.wait();
+
+    expectErrors(stats, 0);
+});


### PR DESCRIPTION
**This PR is just a failing test to demonstrate the bug**
We want to use `hasOwnProperty` as a type guard so we patched `Object` like this:
```TypeScript
interface Object {
  hasOwnProperty<K extends PropertyKey>(k: K): this is {[_ in K]: any }
}
```

This makes code like this valid:
```TypeScript
interface TypeA {}
interface TypeB {
  bar: boolean;
}

type UnionType = TypeA | TypeB;
const foo: UnionType = {
  bar: true
}

if (!foo.hasOwnProperty('bar')) {
  throw new Error();
}

foo.bar
```

The problem we have is that `awesome-typescript-loader` (and `ts-loader`) emits errors as if it didn't saw the `Object` patch but **only on recompile in watch-mode**.

I wrote two tests, one that succeeds without a problem because it just compiles the code once (which demonstrates that this is a watch mode issue) and one that fails despite the fact that the only change that is made between the first compile and the incremental build is a whitespace change.