### PR TITLE
Show errors instead of just showing how many

### DIFF
--- a/src/checker/runtime.ts
+++ b/src/checker/runtime.ts
@@ -396,6 +396,7 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
 
         if (allDiagnostics.length) {
             console.error(colors.red(`\n[${ instanceName }] Checking finished with ${ allDiagnostics.length } errors`));
+            allDiagnostics.map(function(err) { console.error(colors.red(err.messageText)); });
         } else {
             if (!silent) {
                 let timeEnd = +new Date();


### PR DESCRIPTION
Iterate over the allDiagnostics and display error messages.

allDiagnostics.map(function(err) { console.error(colors.red(err.messageText)); });