### PR TITLE
Change the context to webpack provided one

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -43,6 +43,7 @@ export interface Loader {
     emitFile: (fileName: string, text: string) => void;
     emitWarning: (msg: string) => void;
     emitError: (msg: string) => void;
+    context: string;
     options: {
         ts?: LoaderConfig
     };

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -87,7 +87,7 @@ export function ensureInstance(
     }
 
     const watching = isWatching(rootCompiler);
-    const context = webpack.context;
+    const context = webpack.context | process.cwd ();
 
     let compilerInfo = setupTs(query.compiler);
     let { tsImpl } = compilerInfo;

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -87,7 +87,7 @@ export function ensureInstance(
     }
 
     const watching = isWatching(rootCompiler);
-    const context = process.cwd();
+    const context = webpack.context;
 
     let compilerInfo = setupTs(query.compiler);
     let { tsImpl } = compilerInfo;

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -87,7 +87,7 @@ export function ensureInstance(
     }
 
     const watching = isWatching(rootCompiler);
-    const context = webpack.context | process.cwd ();
+    const context = webpack.context || process.cwd ();
 
     let compilerInfo = setupTs(query.compiler);
     let { tsImpl } = compilerInfo;


### PR DESCRIPTION
This allows to run the webpack and sucessfully compiles it from a parent folder, has long as the webpack context is well set.

The path plugin could also benefit from using the webpack context, but the context is passable as an option, so I guess it's fine.