### PR TITLE
Don't kill the loader when compilation.bail = true

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -433,11 +433,6 @@ function setupAfterCompile(compiler, instanceName, forkChecker = false) {
         const asyncErrors = watchMode === WatchMode.Enabled && !silent;
 
         let emitError = (msg) => {
-            if (compilation.bail) {
-                console.error('Error in bail mode:', msg);
-                process.exit(1);
-            }
-
             if (asyncErrors) {
                 console.log(msg, '\n');
             } else {


### PR DESCRIPTION
- Removed check for compilation.bail = true and treat error message as in non-bail mode.
- Loader is not killed anymore (removed process.exit(1)) as this should be done by the caller of the loader.
- All error messages are reported now as they are already generated at that moment (no need to suppress them).