### PR TITLE
fix: environment cache invalidation

### DIFF
--- a/src/__test__/react.ts
+++ b/src/__test__/react.ts
@@ -21,7 +21,7 @@ spec(__filename, async function() {
     src('app.tsx', `
         import * as React from 'react'
 
-        export default class App extends React.Component<{title: string}, void> {
+        export default class App extends React.Component<{title: string}, undefined> {
             render() {
                 return <div>{ this.props.title }</div>
             }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -119,6 +119,7 @@ export function ensureInstance(
 
     let babelImpl = setupBabel(loaderConfig, context);
     let cacheIdentifier = setupCache(
+        compilerConfig,
         loaderConfig,
         tsImpl,
         webpack,
@@ -190,13 +191,13 @@ export function setupTs(compiler: string): CompilerInfo {
 }
 
 function setupCache(
+    compilerConfig: TsConfig,
     loaderConfig: LoaderConfig,
     tsImpl: typeof ts,
     webpack: Loader,
     babelImpl: any,
     context: string
 ) {
-    let cacheIdentifier = null;
     if (loaderConfig.useCache) {
         if (!loaderConfig.cacheDirectory) {
             loaderConfig.cacheDirectory = path.join(context, '.awcache');
@@ -206,13 +207,14 @@ function setupCache(
             mkdirp.sync(loaderConfig.cacheDirectory);
         }
 
-        cacheIdentifier = {
-            'typescript': tsImpl.version,
+        return {
+            typescript: tsImpl.version,
             'awesome-typescript-loader': pkg.version,
-            'awesome-typescript-loader-query': webpack.query,
-            'babel-core': babelImpl
-                ? babelImpl.version
-                : null
+            'babel-core': babelImpl ? babelImpl.version : null,
+            babelPkg: pkg.babel,
+            // TODO: babelrc.json/babelrc.js
+            compilerConfig,
+            env: process.env.BABEL_ENV || process.env.NODE_ENV || 'development'
         };
     }
 }


### PR DESCRIPTION
Previously, the `setupCache` function always returned `undefined`, so it seems that cache invalidation based on the environment has never worked.

This fixes that bug, and also add and removes some parameters for the cacheIdentifier.

Removes:
- `awesome-typescript-loader-query` - because this is already included in the cache key elsewhere (https://github.com/s-panferov/awesome-typescript-loader/blob/master/src/cache.ts#L70)

Adds:
- `compilerConfig` - the typescript compiler configuration
- `babelPkg` - babel config in package.json
- `env` - process environment variables that babel can potentially use


We should also look up the directory tree for `babelrc.js`/`babelrc.json` files, but I think this is at least good start for now.