### PR TITLE
fix(checker): pass through execArgv to checker child process

### DIFF
--- a/src/checker/checker.ts
+++ b/src/checker/checker.ts
@@ -157,7 +157,8 @@ function getExecArgv() {
         if (match) {
             let currentPort = match[3] !== undefined ? +match[3] : match[1] === "debug" ? 5858 : 9229;
             execArgv.push("--" + match[1] + "=" + (currentPort + 1));
-            break;
+        } else {
+            execArgv.push(arg);
         }
     }
 


### PR DESCRIPTION
This allows passing command-line options other than `--debug` and `--inspect` through to the type checker child process, e.g. `--max-old-space-size` to increase the available memory.

We are currently experiencing out-of-memory errors with TypeScript 2.4 and some complex types that we depend on. While we are working on fixing the typings to reduce memory consumption, we wanted to use the `--max-old-space-size` option as a workaround to increase the available memory for the Node.js process. We noticed however that this option is not being passed through to the type checker child process which is created by awesome-typescript-loader, only `--debug` or `--inspect` are passed.

This PR keeps the special treatment for `--debug` and `--inspect`, but passes all other options through to the created child process.