### PR TITLE
Do not use "context" as configFilePath, when parsing config from "con…

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -313,8 +313,7 @@ export function readConfigFile(
                 query.configFileContent || {},
                 tsImpl.sys,
                 context,
-                _.extend({}, tsImpl.getDefaultCompilerOptions(), existingOptions.options) as ts.CompilerOptions,
-                context
+                _.extend({}, tsImpl.getDefaultCompilerOptions(), existingOptions.options) as ts.CompilerOptions
             ),
             loaderConfig: query as LoaderConfig
         };


### PR DESCRIPTION
…figFileContent" setting.

* Removed "context" as optional paramtere "configFilePath" of tsImpl.parseJsonConfigFileContent(...)
* Fixes problems with finding types.