### PR TITLE
Add verbose logging flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ resolve: {
 No logging from the checker. Please note that this option disables async error reporting because
 this option bans `console.log()` usage.
 
+### verbose *(boolean) (default=false)*
+
+Enable verbose logging. Log more than just errors (e.g. typescript path, execution time).
+
 ### compiler *(string) (default='typescript')*
 
 Allows use of TypeScript compilers other than the official one. Must be

--- a/src/checker/runtime.ts
+++ b/src/checker/runtime.ts
@@ -420,9 +420,7 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
     }
 
     function processDiagnostics({ seq }: Diagnostics.Request) {
-        let silent = !!loaderConfig.silent;
-
-        if (!silent) {
+        if (loaderConfig.verbose) {
             console.log(colors.cyan(`\n[${instanceName}] Checking started in a separate process...`));
         }
 

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -112,7 +112,7 @@ export function ensureInstance(
         context
     );
 
-    if (!loaderConfig.silent) {
+    if (loaderConfig.verbose) {
         const sync = watching === WatchMode.Enabled ? ' (in a forked process)' : '';
         console.log(`\n[${instanceName}] Using typescript@${compilerInfo.compilerVersion} from ${compilerInfo.compilerPath} and `
             + `"tsconfig.json" from ${configFilePath}${sync}.\n`);
@@ -437,6 +437,7 @@ function setupAfterCompile(compiler, instanceName, forkChecker = false) {
         const watchMode = isWatching(compilation.compiler);
         const instance: Instance = resolveInstance(compilation.compiler, instanceName);
         const silent = instance.loaderConfig.silent;
+        const verbose = instance.loaderConfig.verbose;
         const asyncErrors = watchMode === WatchMode.Enabled && !silent;
 
         let emitError = (msg) => {
@@ -462,7 +463,7 @@ function setupAfterCompile(compiler, instanceName, forkChecker = false) {
             ? Promise.resolve()
             : instance.checker.getDiagnostics()
                 .then(diags => {
-                    if (!silent) {
+                    if (verbose) {
                         if (diags.length) {
                             console.error(colors.red(`\n[${instanceName}] Checking finished with ${diags.length} errors`));
                         } else {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ export interface LoaderConfig {
     babelOptions?: any;
     usePrecompiledFiles?: boolean;
     silent?: boolean;
+    verbose?: boolean;
     useCache?: boolean;
     cacheDirectory?: string;
     entryFileIsJs?: boolean;


### PR DESCRIPTION
This adds a new configuration flag `verbose` which defaults to `false`. It restricts certain 'verbose' logging of this loader behind this flag.

The rationale behind this change is that this verbose logging can break certain Webpack commands and flows. For example, Webpack has `--json` flag which is supposed to just print the output as JSON, but when this loader is added it  outputs the following:

```
$ webpack --json

[at-loader] Using typescript@2.4.1 from typescript and "tsconfig.json" from /app/tsconfig.json.


[at-loader] Checking started in a separate process...

[at-loader] Ok, 0.341 sec.
{
  "errors": [],
  "warnings": [],
...
```

With this change these verbose messages are no longer output, but errors are still output as usual.