### PR TITLE
Fix custom transformers when using fork checker

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,7 +28,7 @@ export interface LoaderConfig {
     debug?: boolean;
     reportFiles?: string[];
     context?: string;
-    getCustomTransformers?(): ts.CustomTransformers | undefined;
+    getCustomTransformers?: string | (() => ts.CustomTransformers | undefined);
 }
 
 export interface OutputFile {


### PR DESCRIPTION
This is something that we've been using for the past half a year and I thought it'd be good to get it in upstream. Fixes #447.

I guess this does the same thing as this other PR (closes #423) except we're not introducing a new config. If the `getCustomTransformers` is a string, it's assumed to be a module that can be simply required so either something that can be found in the parent `node_modules` or an absolute module path. If it's a function, then the code works as before.

Another difference is that the function is not given the Program object. I don't know how useful this is or not, but it can be easily added.

Let me know if you need me to do anything else for this. Probably a test or two would be in order.