### PR TITLE
Use Error for emitted warn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ function compiler(loader: Loader, text: string): void {
     instance.compiledFiles[fileName] = true;
 
     if (DECLARATION.test(fileName)) {
-        loader.emitWarning(`[${instanceName}] TypeScript declaration files should never be required`);
+        loader.emitWarning(new Error(`[${instanceName}] TypeScript declaration files should never be required`));
         return callback(null, '');
     }
 


### PR DESCRIPTION
The emitter expects to receive an error object instead of a plain string:
```
[0] WARNING in ../my-app/my-file.d.ts
[0] (Emitted value instead of an instance of Error) [at-loader] TypeScript declaration files should never be required
```