### PR TITLE
Specify `transpileOnly` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Specifies the path to a TS config file. This is useful when you have multiple co
 
 ### transpileOnly *(boolean)*
 
-Use this setting to disable type checking.
+Use this setting to disable type checking, enabling this will nullify the `CheckerPlugin` usage in your webpack configuration.
 
 ### errorsAsWarnings *(boolean)*
 


### PR DESCRIPTION
when enabling `transpileOnly`, even there is `CheckerPlugin` configrated in webpack.config.js, it will not take effect.

ideally we should print some warning in this situation but I think a precise notice in the docs should be sufficient at this moment.