### PR TITLE
cleanup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
     "lodash": "^4.17.4",
     "micromatch": "^3.0.3",
     "mkdirp": "^0.5.1",
-    "object-assign": "^4.1.1",
-    "source-map-support": "^0.4.15"
+    "source-map-support": "^0.5.3"
+  },
+  "peerDependencies": {
+    "typescript": "^2"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -392,7 +392,7 @@ function setupWatchRun(compiler, instanceName: string) {
         instance.watchedFiles = set;
 
         const instanceTimes = instance.times;
-        instance.times = Object.assign({}, times) as any;
+        instance.times = { ...times } as any;
 
         const changedFiles = Object.keys(times)
         .filter(fileName => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2170,7 +2170,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2755,11 +2755,11 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+source-map-support@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
   dependencies:
-    source-map "^0.5.6"
+    source-map "^0.6.0"
 
 source-map-url@^0.4.0:
   version "0.4.0"
@@ -2778,6 +2778,10 @@ source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
* depends on the latest `source-map-support`
* no need to depend on `object-assign`, use the object-spread operator instead
* add `typescript` to peedDependencies