### PR TITLE
Fixes for Webpack 4, contributes towards #534

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -364,14 +364,14 @@ const filterMtimes = (mtimes: any) => {
 }
 
 function setupWatchRun(compiler, instanceName: string) {
-	compiler.plugin('watch-run', function(watching, callback) {
-		const instance = resolveInstance(watching.compiler, instanceName)
+	compiler.hooks.watchRun.tap('at-loader', function (compiler, callback) {
+		const instance = resolveInstance(compiler, instanceName)
 		const checker = instance.checker
 		const watcher =
-			watching.compiler.watchFileSystem.watcher ||
-			watching.compiler.watchFileSystem.wfs.watcher
+			compiler.watchFileSystem.watcher ||
+			compiler.watchFileSystem.wfs.watcher
 
-		const startTime = instance.startTime || watching.startTime
+		const startTime = instance.startTime || compiler.startTime
 		const times = filterMtimes(watcher.getTimes())
 		const lastCompiled = instance.compiledFiles
 
@@ -442,7 +442,7 @@ function isWatching(compiler: any): WatchMode {
 }
 
 function setupAfterCompile(compiler, instanceName, forkChecker = false) {
-	compiler.plugin('after-compile', function(compilation, callback) {
+	compiler.hooks.afterCompile.tap('at-loader', function (compilation, callback) {
 		// Don"t add errors for child compilations
 		if (compilation.compiler.isChild()) {
 			callback()

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -467,12 +467,7 @@ function setupAfterCompile(compiler, instanceName, forkChecker = false) {
 		}
 
 		const files = instance.checker.getFiles().then(({ files }) => {
-			const normalized = files.map(file => {
-				const rpath = path.normalize(file)
-				instance.compiledFiles[file] = true
-				return rpath
-			})
-			Array.prototype.push.apply(compilation.fileDependencies, normalized)
+			Array.prototype.push.apply(compilation.fileDependencies, files.map(path.normalize))
 		})
 
 		const timeStart = +new Date()

--- a/src/watch-mode.ts
+++ b/src/watch-mode.ts
@@ -2,12 +2,12 @@ export const WatchModeSymbol = Symbol('WatchMode')
 
 export class CheckerPlugin {
 	apply(compiler) {
-		compiler.plugin('run', function(params, callback) {
+		compiler.hooks.run.tap('at-loader', function (params, callback) {
 			compiler[WatchModeSymbol] = false
 			callback()
 		})
 
-		compiler.plugin('watch-run', function(params, callback) {
+		compiler.hooks.watchRun.tap('at-loader', function (params, callback) {
 			compiler[WatchModeSymbol] = true
 			callback()
 		})


### PR DESCRIPTION
- Move to the new Tapable API.
- Remove`instance.checker.getFiles()` from being placed into `instance.compiledFiles`. This prevents files loaded automatically by the typescript compiler, such as `typescript/lib/lib.dom.d.ts`, from being incorrectly set as removed when the Webpack watcher runs. This is because such files are not known to the Webpack watcher and are missing from `watcher.getTimes()`.