### PR TITLE
fix default library path discovery on Windows OS

### DIFF
--- a/src/checker/runtime.ts
+++ b/src/checker/runtime.ts
@@ -158,10 +158,10 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
 	}
 
 	function getDefaultLibFileName(options: ts.CompilerOptions) {
-		return path.join(
+		return toUnix(path.join(
 			path.dirname(compiler.sys.getExecutingFilePath()),
 			compiler.getDefaultLibFileName(options)
-		)
+		))
 	}
 
 	function invokeWatcherCallbacks(


### PR DESCRIPTION
In your implementation getDefaultLibLocation function is not implemented. Therefore `ts.getDirectoryPath(getDefaultLibraryFileName())` will be called which returns drive letter if called with Windows slashes which is wrong.

Though might be implementing getDefaultLibLocation will be a bit better solution but keep in mind:
1. Some functions are not accessible in .d.ts
2. This still causes issues and needs to be fixed.

So I think this solution is perfectly fine. closes #548. Worth mentioning #534 