### PR TITLE
Use webpack-log for nicer logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "husky": "^0.14.3",
     "typescript": "^2.7.2",
     "webpack": "^4.1.0",
-    "webpack-cli": "^2.0.10"
+    "webpack-cli": "^2.0.10",
+    "webpack-log": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,6 +3835,10 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
+loglevelnext@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.3.tgz#0f69277e73bbbf2cd61b94d82313216bf87ac66e"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -5454,7 +5458,7 @@ staged-git-files@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.0.tgz#1a9bb131c1885601023c7aaddd3d54c22142c526"
 
-standard-version@^4.2.0:
+standard-version@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-4.3.0.tgz#41006cfee4eeab7c0ff3a47eecaa4c7506ed2e3f"
   dependencies:
@@ -6098,6 +6102,15 @@ webpack-cli@^2.0.10:
     yargs "9.0.1"
     yeoman-environment "^2.0.0"
     yeoman-generator "github:ev1stensberg/generator#Feature-getArgument"
+
+webpack-log@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    loglevelnext "^1.0.1"
+    uuid "^3.1.0"
 
 webpack-sources@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Closes #567.

I just opened #567 and actually decided to give it a shot myself. I find the result pretty enjoyable actually, well integrated with other Webpack tooling when building.

Note that I have only changed what I was able to output, so there are a bunch of other `console.{log,error}` that I left untouched. I think they can be switched iteratively, but also happy to take care of them if you want me to, in which case I would appreciate further instructions how to trigger them :)

Some results:

Before | After
--- | ---
<img width="618" alt="screen shot 2018-04-06 at 14 52 41" src="https://user-images.githubusercontent.com/113730/38439017-340aceb6-39aa-11e8-80cb-8e984ad6c4da.png"> | <img width="384" alt="screen shot 2018-04-06 at 14 51 57" src="https://user-images.githubusercontent.com/113730/38439023-375ad14c-39aa-11e8-8ea3-4aa6becc4dd9.png">

With `debug` on:

<img width="352" alt="screen shot 2018-04-06 at 14 36 53" src="https://user-images.githubusercontent.com/113730/38439355-4f5867ae-39ab-11e8-980b-62dc77cd5f93.png">
<img width="356" alt="screen shot 2018-04-06 at 14 41 16" src="https://user-images.githubusercontent.com/113730/38439354-4f497884-39ab-11e8-9565-be74870121bf.png">
