### PR TITLE
Assertion check for webpack version

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -137,6 +137,12 @@ export function ensureInstance(
 	)
 	let compiler = <any>webpack._compiler
 
+	if (!rootCompiler.hooks) {
+		throw new Error('It looks like you\'re using an old webpack version without hooks support. ' +
+						'If you\'re using awesome-script-loader with React storybooks consider ' +
+						'upgrading @storybook/react to at least version 4.0.0-alpha.3');
+	}
+
 	setupWatchRun(compiler, instanceName)
 	setupAfterCompile(compiler, instanceName)
 


### PR DESCRIPTION
It looks like awesome-typescript-loader@5 works with at least webpack version 4 but this is not checked in its code. So the errors that users get look like this:

```
TypeError: Cannot read property 'watchRun' of undefined
    at setupWatchRun (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/instance.ts:372:16)
    at Object.ensureInstance (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/instance.ts:141:2)
    at compiler (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/index.ts:47:19)
    at Object.loader (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/index.ts:16:12)
    at LOADER_EXECUTION (/Users/dsorin/ecosystem/dac/node_modules/loader-runner/lib/LoaderRunner.js:119:14)
    at runSyncOrAsync (/Users/dsorin/ecosystem/dac/node_modules/loader-runner/lib/LoaderRunner.js:120:4)
    at iterateNormalLoaders (/Users/dsorin/ecosystem/dac/node_modules/loader-runner/lib/LoaderRunner.js:229:2)
    at Array.<anonymous> (/Users/dsorin/ecosystem/dac/node_modules/loader-runner/lib/LoaderRunner.js:202:4)
    at Storage.finished (/Users/dsorin/ecosystem/dac/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:40:15)
    at /Users/dsorin/ecosystem/dac/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:77:9
    at /Users/dsorin/ecosystem/dac/node_modules/graceful-fs/graceful-fs.js:78:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:511:3) 'TypeError: Cannot read property \'watchRun\' of undefined\n    at setupWatchRun (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/instance.ts:372:16)\n    at Object.ensureInstance (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/instance.ts:141:2)\n    at compiler (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/index.ts:47:19)\n    at Object.loader (/Users/dsorin/ecosystem/dac/packages/app-management-apollo/node_modules/awesome-typescript-loader/src/index.ts:16:12)\n    at LOADER_EXECUTION (/Users/dsorin/ecosystem/dac/node_modules/loader-runner/lib/LoaderRunner.
```

That's not helpful, especially when you're using React storybooks and you get webpack@2 [by default](https://github.com/storybooks/storybook/issues/3044) 🤦‍♂️ 