### PR TITLE
fix: Changed declaration generation to generate .d.ts files for all f…

### DIFF
--- a/src/checker/checker.ts
+++ b/src/checker/checker.ts
@@ -14,7 +14,8 @@ import {
 	Diagnostics,
 	UpdateFile,
 	TsConfig,
-	RemoveFile
+	RemoveFile,
+	EmitDeclaration
 } from './protocol'
 
 export interface Resolve {
@@ -109,6 +110,15 @@ export class Checker {
 				text
 			}
 		} as EmitFile.Request)
+	}
+
+	emitDeclaration(fileName: string): Promise<EmitDeclaration.ResPayload> {
+		return this.req({
+			type: 'EmitDeclaration',
+			payload: {
+				fileName
+			}
+		} as EmitDeclaration.Request)
 	}
 
 	updateFile(fileName: string, text: string, ifExist = false) {

--- a/src/checker/protocol.ts
+++ b/src/checker/protocol.ts
@@ -8,6 +8,7 @@ export type MessageType =
 	| 'EmitFile'
 	| 'Files'
 	| 'RemoveFile'
+	| 'EmitDeclaration'
 
 export const MessageType = {
 	Init: 'Init' as 'Init',
@@ -15,7 +16,8 @@ export const MessageType = {
 	UpdateFile: 'UpdateFile' as 'UpdateFile',
 	RemoveFile: 'RemoveFile' as 'RemoveFile',
 	Diagnostics: 'Diagnostics' as 'Diagnostics',
-	EmitFile: 'EmitFile' as 'EmitFile'
+	EmitFile: 'EmitFile' as 'EmitFile',
+	EmitDeclaration: 'EmitDeclaration' as 'EmitDeclaration'
 }
 
 export interface ReqBase {
@@ -30,6 +32,7 @@ export type Req =
 	| Diagnostics.Request
 	| RemoveFile.Request
 	| Files.Request
+	| EmitDeclaration.Request
 
 export interface Res {
 	seq?: number
@@ -109,6 +112,26 @@ export namespace EmitFile {
 			declaration: { name: string; text: string }
 		}
 		deps: string[]
+	}
+
+	export interface Response extends Res {
+		payload: ResPayload
+	}
+}
+
+export namespace EmitDeclaration {
+	export interface ReqPayload {
+		fileName: string
+	}
+
+	export interface Request extends ReqBase {
+		type: 'EmitDeclaration'
+		payload: ReqPayload
+	}
+
+	export interface ResPayload {
+		name: string
+		text: string
 	}
 
 	export interface Response extends Res {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,8 @@ function compiler(loader: Loader, text: string): void {
 
 			if (!isolated && result.deps) {
 				// If our modules are isolated we don"t need to recompile all the deps
+				// This only tracks the fileDependencies for the watch functionality,
+				// it doesn't actually add the dependencies to be loaded
 				result.deps.forEach(dep => loader.addDependency(path.normalize(dep)))
 			}
 			if (cached) {
@@ -165,10 +167,6 @@ function transform(
 			resultSourceMap.sources = [sourcePath]
 			resultSourceMap.file = fileName
 			resultSourceMap.sourcesContent = [text]
-		}
-
-		if (emitResult.declaration) {
-			instance.compiledDeclarations.push(emitResult.declaration)
 		}
 
 		return {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -34,7 +34,7 @@ export interface LoaderConfig {
 export interface OutputFile {
 	text: string
 	sourceMap: string
-	declaration: ts.OutputFile
+	declaration?: ts.OutputFile
 }
 
 export type TsConfig = ts.ParsedCommandLine


### PR DESCRIPTION
…les, including those that produce no javascript

This fix addresses issues mentioned in 
* https://github.com/s-panferov/awesome-typescript-loader/issues/432
* https://github.com/s-panferov/awesome-typescript-loader/issues/428
* https://github.com/s-panferov/awesome-typescript-loader/issues/411
* And potentially others.

The reason this issue is occurring is that adding a dependency to the loader does not guarantee that the loader will be run for the file that was added.  The dependencies that are added are only added to the `fileDependencies` property in the loader, so webpack only cares about them from a watch standpoint.  

Dependencies that need to be run by the loader are computed from the output of the acorn compiler.  In this case, since there is no actual source code generated from the interface file, the compiler generates no dependencies and doesn't run the loader on the file.

I have created a sample repository here:
https://github.com/bkrupa-argo/atl-interface-webpack4-repro

Additionally, I have another branch that fixes the issue in webpack 3 (as that is the version I am currently working in).  Would you like me to contribute that change back as well?