### PR TITLE
feat: pass ts.Program as an argument for getCustomTransformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,32 @@ reportFiles: [
 ]
 ```
 
+### getCustomTransformers *(string | ((program: ts.Program) => ts.CustomTransformers | undefined)) (default=undefined)*
+
+Provide custom transformers, TypeScript 2.4.1+. Example:
+
+```js
+const styledComponentsTransformer = require('typescript-plugin-styled-components').default;
+const keysTransformer = require('ts-transformer-keys/transformer').default;
+
+// ...
+rules: [
+    {
+        test: /\.tsx?$/,
+        loader: 'awesome-typescript-loader',
+        options: {
+            // ... other loader's options
+            getCustomTransformers: program => ({
+                before: [
+                    styledComponentsTransformer(),
+                    keysTransformer(program)
+                ]
+            })
+        }
+    }
+]
+```
+
 ## Compiler options
 
 You can pass compiler options inside the loader query string or in a TS config file.

--- a/src/__test__/custom-transformers.ts
+++ b/src/__test__/custom-transformers.ts
@@ -1,0 +1,40 @@
+import {src, webpackConfig, tsconfig, compile, checkOutput, expectErrors, spec, expect, query} from './utils'
+
+[true, false].forEach(transpileOnly => {
+	spec(`${__filename}-transpileOnly:${transpileOnly}`, async function() {
+		src(
+			'index.ts',
+			`
+			class HiThere {
+				constructor(a: number, b: string) {
+					const t = a + b;
+				}
+			}
+		`
+		)
+
+		tsconfig()
+		let getCustomTransformersCalled = false
+		let stats = await compile(webpackConfig(query({
+			transpileOnly,
+			getCustomTransformers: program => {
+				expect(typeof program.getTypeChecker === 'function').true
+				getCustomTransformersCalled = true
+				return {};
+			}
+		})))
+
+		expectErrors(stats, 0)
+		checkOutput(
+			'index.js',
+			`
+			class HiThere {
+				constructor(a, b) {
+					const t = a + b;
+				}
+			}
+		`
+		)
+		expect(getCustomTransformersCalled).true
+	})
+})

--- a/src/checker/runtime.ts
+++ b/src/checker/runtime.ts
@@ -104,7 +104,7 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
 	let watchHost: WatchHost
 	let watch: ts.WatchOfFilesAndCompilerOptions<ts.SemanticDiagnosticsBuilderProgram>
 
-	let finalTransformers: undefined | (() => ts.CustomTransformers)
+	let finalTransformers: undefined | ((program: ts.Program) => ts.CustomTransformers)
 
 	function createWatchHost(): WatchHost {
 		return {
@@ -410,7 +410,7 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
 			writeFile,
 			/*cancellationToken*/ undefined,
 			/*emitOnlyDtsFiles*/ false,
-			finalTransformers && finalTransformers()
+			finalTransformers && finalTransformers(program.getProgram())
 		)
 		return outputFiles
 	}
@@ -433,7 +433,8 @@ function createChecker(receive: (cb: (msg: Req) => void) => void, send: (msg: Re
 		const trans = compiler.transpileModule(files.get(fileName).text, {
 			compilerOptions: compilerOptions,
 			fileName,
-			reportDiagnostics: false
+			reportDiagnostics: false,
+			transformers: finalTransformers ? finalTransformers(getProgram().getProgram()) : undefined
 		})
 
 		return {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,7 +28,7 @@ export interface LoaderConfig {
 	debug?: boolean
 	reportFiles?: string[]
 	context?: string
-	getCustomTransformers?: string | (() => ts.CustomTransformers | undefined)
+	getCustomTransformers?: string | ((program: ts.Program) => ts.CustomTransformers | undefined)
 }
 
 export interface OutputFile {


### PR DESCRIPTION
This enables using custom transformers which require `ts.Program`.
The feature has been already supported by [rollup-plugin-typescript2](https://github.com/ezolenko/rollup-plugin-typescript2).