### PR TITLE
fix(cache): use object-hash to invoke function options

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "lodash": "^4.17.5",
     "micromatch": "^3.1.9",
     "mkdirp": "^0.5.1",
+    "object-hash": "^1.3.0",
     "source-map-support": "^0.5.3",
+    "tslib": "^1.9.3",
     "webpack-log": "^1.2.0"
   },
   "peerDependencies": {
@@ -51,6 +53,7 @@
     "@types/micromatch": "^3.1.0",
     "@types/mocha": "^5.2.1",
     "@types/node": "^10.3.2",
+    "@types/object-hash": "^1.2.0",
     "@types/shelljs": "^0.8.0",
     "@types/sinon": "^5.0.1",
     "@types/webpack": "^4.4.0",

--- a/src/__test__/cache-filename.ts
+++ b/src/__test__/cache-filename.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2018 acrazing <joking.young@gmail.com>. All rights reserved.
+ * @since 2018-08-02 10:40:34
+ */
+
+import { filename } from '../cache'
+import { LoaderConfig } from '../interfaces'
+import { expect, spec } from './utils'
+
+spec(__filename, async () => {
+	const optA: LoaderConfig = {
+		useCache: true
+	}
+	const optB: LoaderConfig = {
+		...optA,
+		getCustomTransformers: () => ({
+			before: []
+		})
+	}
+	expect(filename('', '', optA)).not.equal(filename('', '', optB))
+})

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import * as zlib from 'zlib'
-import { createHash } from 'crypto'
+import objectHash = require('object-hash')
 
 export interface CompiledModule {
 	fileName: string
@@ -59,17 +59,14 @@ function write(filename: string, result: any) {
  *
  * @return {String}
  */
-function filename(source: string, identifier, options) {
-	let hash = createHash('sha512') as any
-	let contents = JSON.stringify({
+export function filename(source: string, identifier, options) {
+	let basename = objectHash({
 		identifier: identifier,
 		options: options,
 		source: source
 	})
 
-	hash.end(contents)
-
-	return hash.read().toString('hex') + '.json.gzip'
+	return basename + '.json.gzip'
 }
 
 export interface CacheParams<T> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,32 @@
 {
-    "compilerOptions": {
-        "target": "es5",
-        "outDir": "dist",
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "skipDefaultLibCheck": true,
-        "sourceMap": true,
-        "declaration": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": false,
-        "noFallthroughCasesInSwitch": true,
-        "removeComments": true,
-        "suppressImplicitAnyIndexErrors": true,
-        "lib": [ "es6", "dom" ],
-        "types" : ["node", "lodash", "mocha"]
-    },
-    "include": [
-        "src/**/*"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+	"compilerOptions": {
+		"target": "es5",
+		"outDir": "dist",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"skipDefaultLibCheck": true,
+		"sourceMap": true,
+		"declaration": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": false,
+		"noFallthroughCasesInSwitch": true,
+		"removeComments": true,
+		"suppressImplicitAnyIndexErrors": true,
+		"lib": [
+			"es6",
+			"dom"
+		],
+		"importHelpers": true,
+		"types": [
+			"node",
+			"lodash",
+			"mocha"
+		]
+	},
+	"include": [
+		"src/**/*"
+	],
+	"exclude": [
+		"node_modules"
+	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,10 @@
   version "10.3.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.2.tgz#3840ec6c12556fdda6e0e6d036df853101d732a4"
 
+"@types/object-hash@^1.2.0":
+  version "1.2.0"
+  resolved "http://registry.npm.taobao.org/@types/object-hash/download/@types/object-hash-1.2.0.tgz#d65904331bd0b05c7d5ece75f9ddfdbe82affd30"
+
 "@types/shelljs@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.0.tgz#0caa56b68baae4f68f44e0dd666ab30b098e3632"
@@ -2668,6 +2672,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^1.3.0:
+  version "1.3.0"
+  resolved "http://registry.npm.taobao.org/object-hash/download/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
+
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
@@ -3683,6 +3691,10 @@ trim-off-newlines@^1.0.0:
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
+
+tslib@^1.9.3:
+  version "1.9.3"
+  resolved "http://registry.npm.taobao.org/tslib/download/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tslint@^5.10.0:
   version "5.10.0"


### PR DESCRIPTION
Currently, the cache filename use `JSON.stringify` to create cache key, it could not process function options just like `getCustomTransformers`, this PR changes it to use `object-hash` to process it.