### PR TITLE
fix: checker should also watch change in json files

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -364,7 +364,7 @@ export function readConfigFile(
 	}
 }
 
-let EXTENSIONS = /\.tsx?$|\.jsx?|.json$/
+let EXTENSIONS = /\.tsx?$|\.jsx?$|\.json$/
 export type Dict<T> = { [key: string]: T }
 
 const filterMtimes = (mtimes: any) => {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -364,7 +364,7 @@ export function readConfigFile(
 	}
 }
 
-let EXTENSIONS = /\.tsx?$|\.jsx?$/
+let EXTENSIONS = /\.tsx?$|\.jsx?|.json$/
 export type Dict<T> = { [key: string]: T }
 
 const filterMtimes = (mtimes: any) => {


### PR DESCRIPTION
People using `resolveJsonModule: true` get at-loader error about their json export, because checker doesn't pick up changes in any `.json` files.

This patch add `.json` as a valid file extension to be considered changed.

background: https://stackoverflow.com/questions/54695319/awesome-typescript-loader-does-not-pick-up-changes-in-json