### PR TITLE
fix(dependencies): update micromatch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "enhanced-resolve": "^4.0.0",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
-    "micromatch": "^3.1.9",
+    "micromatch": "^4.0.2",
     "mkdirp": "^0.5.1",
     "source-map-support": "^0.5.3",
     "webpack-log": "^1.2.0"


### PR DESCRIPTION
The current version of micromatch depends on an outdated version of 'set-value' which
contains a security vulnerability (see https://nvd.nist.gov/vuln/detail/CVE-2019-10747)
The latest version of micromatch does not include this dependency