### PR TITLE
fix(dependencies): update micromatch and node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
   - yarn install
   - yarn run build
 node_js:
-  - "7"
+  - "8"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ After that, you will be able to build TypeScript files with webpack.
 
 ## NodeJS versions
 
-**The loader supports NodeJS 4 and newer.**
+**The loader supports NodeJS 8 and newer.**
 
 ## tsconfig.json
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  nodejs_version: "6"
+  nodejs_version: "8"
   matrix:
   - TYPESCRIPT: typescript@2.7.2
 cache:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "enhanced-resolve": "^4.0.0",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
-    "micromatch": "^3.1.9",
+    "micromatch": "^4.0.2",
     "mkdirp": "^0.5.1",
     "source-map-support": "^0.5.3",
     "webpack-log": "^1.2.0"


### PR DESCRIPTION
The current version of micromatch depends on an outdated version of 'set-value' which
contains a security vulnerability (see https://nvd.nist.gov/vuln/detail/CVE-2019-10747)
The latest version of micromatch does not include this dependency, but requires node 8 or greater.